### PR TITLE
Moar testing: Run against Spark 2 and 1.5 with docker, run test-all in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  services:
+    - docker

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  hosts:
+    master: 127.0.0.1
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ machine:
     - docker
 
 test:
+  override:
+    - lein test-all
   post:
     - lein with-profile spark2 test :only powderkeg.integration-test/rdd-spark-2.1.0
     - lein with-profile spark1.5 test :only powderkeg.integration-test/rdd-spark-1.5.2

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
 machine:
   services:
     - docker
+
+test:
+  post:
+    - lein with-profile spark2 test :only powderkeg.integration-test/rdd-spark-2.1.0
+    - lein with-profile spark1.5 test :only powderkeg.integration-test/rdd-spark-1.5.2

--- a/conf/master/spark-defaults.conf
+++ b/conf/master/spark-defaults.conf
@@ -1,0 +1,12 @@
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+spark.driver.port 7001
+spark.fileserver.port 7002
+spark.broadcast.port 7003
+spark.replClassServer.port 7004
+spark.blockManager.port 7005
+spark.executor.port 7006
+
+spark.broadcast.factory=org.apache.spark.broadcast.HttpBroadcastFactory
+spark.port.maxRetries 4

--- a/conf/worker/spark-defaults.conf
+++ b/conf/worker/spark-defaults.conf
@@ -1,0 +1,12 @@
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+#spark.driver.port 7101
+spark.fileserver.port 7012
+spark.broadcast.port 7013
+spark.replClassServer.port 7014
+spark.blockManager.port 7015
+spark.executor.port 7016
+
+spark.broadcast.factory=org.apache.spark.broadcast.HttpBroadcastFactory
+spark.port.maxRetries 4

--- a/project.clj
+++ b/project.clj
@@ -26,4 +26,5 @@
                  [com.cemerick/pomegranate "0.3.0"]]
   :aot [powderkeg.repl]
   :java-source-paths ["src/main/java"]
-  :source-paths ["src/main/clojure"])
+  :source-paths ["src/main/clojure"]
+  :target-path "target/%s/")

--- a/project.clj
+++ b/project.clj
@@ -7,17 +7,18 @@
   :test-selectors {:default (complement :integration)
                    :integration :integration}
   :profiles {:default [:spark2]
-             :spark2 [:leiningen/default :spark2-deps]
-             :spark1.5 [:leiningen/default :spark1.5-deps]
+             :spark2 [:leiningen/default :spark2-deps :kryo-4]
+             :spark1.5 [:leiningen/default :spark1.5-deps :kryo-3]
              :spark2-deps ^{:pom-scope :provided}
              {:dependencies [[org.apache.spark/spark-core_2.11 "2.1.0"]
                              [org.apache.spark/spark-streaming_2.11 "2.1.0"]]}
              :spark1.5-deps ^{:pom-scope :provided}
              {:dependencies [[org.apache.spark/spark-core_2.10 "1.5.2"]
-                             [org.apache.spark/spark-streaming_2.10 "1.5.2"]]}}
+                             [org.apache.spark/spark-streaming_2.10 "1.5.2"]]}
+             :kryo-3 {:dependencies [[com.esotericsoftware/kryo-shaded "3.0.3"]]}
+             :kryo-4 {:dependencies [[com.esotericsoftware/kryo-shaded "4.0.0"]]}}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [net.cgrand/xforms "0.5.1"]
-                 [com.esotericsoftware/kryo-shaded "4.0.0"]
                  [com.twitter/carbonite "1.4.0" :exclusions [com.twitter/chill-java]]
                  [com.cemerick/pomegranate "0.3.0"]]
   :aot [powderkeg.repl]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   
   :aliases {"test-all" ["with-profile" "spark1.5:spark2" "test"]}
-  
+  :test-selectors {:default (complement :integration)
+                   :integration :integration}
   :profiles {:default [:spark2]
              :spark2 [:leiningen/default :spark2-deps]
              :spark1.5 [:leiningen/default :spark1.5-deps]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,6 @@
   :url "https://github.com/HCADatalab/powderkeg"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  
   :aliases {"test-all" ["with-profile" "spark1.5:spark2" "test"]}
   :test-selectors {:default (complement :integration)
                    :integration :integration}
@@ -11,18 +10,15 @@
              :spark2 [:leiningen/default :spark2-deps]
              :spark1.5 [:leiningen/default :spark1.5-deps]
              :spark2-deps ^{:pom-scope :provided}
-                      {:dependencies [[org.apache.spark/spark-core_2.11 "2.1.0"]
-                                      [org.apache.spark/spark-streaming_2.11 "2.1.0"]]}
+             {:dependencies [[org.apache.spark/spark-core_2.11 "2.1.0"]
+                             [org.apache.spark/spark-streaming_2.11 "2.1.0"]]}
              :spark1.5-deps ^{:pom-scope :provided}
-                        {:dependencies [[org.apache.spark/spark-core_2.10 "1.5.2"]
-                                        [org.apache.spark/spark-streaming_2.10 "1.5.2"]]}}
+             {:dependencies [[org.apache.spark/spark-core_2.10 "1.5.2"]
+                             [org.apache.spark/spark-streaming_2.10 "1.5.2"]]}}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 
                  [net.cgrand/xforms "0.5.1"]
-                 
                  [com.esotericsoftware/kryo-shaded "4.0.0"]
-                 [com.twitter/carbonite "1.4.0"
-                  :exclusions [com.twitter/chill-java]]
+                 [com.twitter/carbonite "1.4.0" :exclusions [com.twitter/chill-java]]
                  [com.cemerick/pomegranate "0.3.0"]]
   :aot [powderkeg.repl]
   :java-source-paths ["src/main/java"]

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -10,6 +10,11 @@
       (throw (Exception. (str "Problem while running '" (s/join " " args) "': " out " " err))))
     (.trim out)))
 
+(defn path-to-spark-class [version]
+  (condp = version
+    "2.1.0-hadoop-2.7" "/usr/spark-2.1.0/bin/spark-class"
+    "1.5.2-hadoop-2.6" "/usr/spark/bin/spark-class"))
+
 (defn start-master [pwd version]
   (sh! "docker" "run" "-d"
        "--name" "master"
@@ -26,7 +31,7 @@
        "-v" (str pwd "/conf/master:/conf")
        "-v" (str pwd "/data:/tmp/data")
        (str "gettyimages/spark:" version)
-       "/usr/spark/bin/spark-class"
+       (path-to-spark-class version)
        "org.apache.spark.deploy.master.Master"
        "-h" "master"))
 
@@ -46,7 +51,7 @@
        "-e" "SPARK_WORKER_PORT=8881"
        "-e" "SPARK_WORKER_WEBUI_PORT=8081"
        (str "gettyimages/spark:" version)
-       "/usr/spark/bin/spark-class"
+       (path-to-spark-class version)
        "org.apache.spark.deploy.worker.Worker" "spark://master:7077"))
 
 (defn stop-spark [instance]

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -94,15 +94,15 @@
     (.setContextClassLoader (Thread/currentThread) (clojure.lang.DynamicClassLoader. cl))
     #(.setContextClassLoader (Thread/currentThread) cl)))
 
-(defn keg-connection []
-  (keg/connect! "spark://localhost:7077")
+(defn keg-connection [host]
+  (keg/connect! (str "spark://" host ":7077"))
   #(keg/disconnect!))
 
 (deftest ^:integration rdd-spark-2.1.0
   (with-resources
     [(spark "2.1.0-hadoop-2.7")
      clojure-dynamic-classloader
-     keg-connection]
+     (keg-connection "localhost")]
     (is (= (into [] (keg/rdd (range 10)))
            (range 10)))))
 
@@ -110,6 +110,6 @@
   (with-resources
     [(spark "1.5.2-hadoop-2.6")
      clojure-dynamic-classloader
-     keg-connection]
+     (keg-connection "master")]
     (is (= (into [] (keg/rdd (range 10)))
            (range 10)))))

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -57,9 +57,9 @@
 (defn with-cluster [f]
   (let [pwd (.getAbsolutePath (java.io.File. ""))]
     (start-master pwd)
-    (Thread/sleep 4000)
+    (Thread/sleep 2000)
     (start-worker pwd)
-    (Thread/sleep 4000))
+    (Thread/sleep 2000))
   (f)
   (stop-spark "worker")
   (stop-spark "master"))

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -17,7 +17,7 @@
 
 (defn start-master [pwd version]
   (sh! "docker" "run" "-d"
-       "--name" "master"
+       "--name" (str "master-" version)
        "-h" "master"
        "-p" "8080:8080"
        "-p" "7077:7077"
@@ -37,8 +37,8 @@
 
 (defn start-worker [pwd version]
   (sh! "docker" "run" "-d"
-       "--name" "worker"
-       "--link" "master"
+       "--name" (str "worker-" version)
+       "--link" (str "master-" version)
        "-h" "worker"
        "--expose" "7012-7016"
        "--expose" "8881"
@@ -80,14 +80,14 @@
     (start-worker pwd version)
     (Thread/sleep 2000)))
 
-(defn stop-cluster []
-  (stop-spark "worker")
-  (stop-spark "master"))
+(defn stop-cluster [version]
+  (stop-spark (str "worker-" version))
+  (stop-spark (str "master-" version)))
 
 (defn spark [version]
   (fn []
     (start-spark version)
-    stop-cluster))
+    #(stop-cluster version)))
 
 (defn clojure-dynamic-classloader []
   (let [cl (.getContextClassLoader (Thread/currentThread))]

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -8,7 +8,7 @@
   (let [{:keys [exit out] :as ret} (apply sh args)]
     (when-not (zero? exit)
       (throw (Exception. (str "Problem while running '" (s/join " " args) "': " out))))
-    out))
+    (.trim out)))
 
 (defn start-master [pwd]
   (sh! "docker" "run" "-d"

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -10,48 +10,58 @@
       (throw (Exception. (str "Problem while running '" (s/join " " args) "': " out))))
     out))
 
+(defn start-master [pwd]
+  (sh! "docker" "run" "-d"
+       "--name" "master"
+       "-h" "master"
+       "-p" "8080:8080"
+       "-p" "7077:7077"
+       "-p" "4040:4040"
+       "-p" "6066:6066"
+       "--expose" "7001-7006"
+       "--expose" "7077"
+       "--expose" "6066"
+       "-e" "MASTER=spark://master:7077"
+       "-e" "SPARK_CONF_DIR=/conf"
+       "-v" (str pwd "/conf/master:/conf")
+       "-v" (str pwd "/data:/tmp/data")
+       "gettyimages/spark"
+       "bin/spark-class"
+       "org.apache.spark.deploy.master.Master"
+       "-h" "master"))
+
+(defn start-worker [pwd]
+  (sh! "docker" "run" "-d"
+       "--name" "worker"
+       "--link" "master"
+       "-h" "worker"
+       "--expose" "7012-7016"
+       "--expose" "8881"
+       "-p" "8081:8081"
+       "-e" "SPARK_CONF_DIR=/conf"
+       "-v" (str pwd "/conf/worker:/conf")
+       "-v" (str pwd "/data:/tmp/data")
+       "-e" "SPARK_WORKER_CORES=2"
+       "-e" "SPARK_WORKER_MEMORY=1g"
+       "-e" "SPARK_WORKER_PORT=8881"
+       "-e" "SPARK_WORKER_WEBUI_PORT=8081"
+       "gettyimages/spark"
+       "bin/spark-class"
+       "org.apache.spark.deploy.worker.Worker" "spark://master:7077"))
+
+(defn stop-spark [instance]
+  (sh! "docker" "stop" instance)
+  (sh! "docker" "rm" instance))
+
 (defn with-cluster [f]
   (let [pwd (.getAbsolutePath (java.io.File. ""))]
-    (sh! "docker" "run" "-d"
-         "--name" "master"
-         "-h" "master"
-         "-p" "8080:8080"
-         "-p" "7077:7077"
-         "-p" "4040:4040"
-         "-p" "6066:6066"
-         "--expose" "7001-7006"
-         "--expose" "7077"
-         "--expose" "6066"
-         "-e" "MASTER=spark://master:7077"
-         "-e" "SPARK_CONF_DIR=/conf"
-         "-v" (str pwd "/conf/master:/conf")
-         "-v" (str pwd "/data:/tmp/data")
-         "gettyimages/spark"
-         "bin/spark-class"
-         "org.apache.spark.deploy.master.Master"
-         "-h" "master")
-    (sh! "docker" "run" "-d"
-         "--name" "worker"
-         "--link" "master"
-         "-h" "worker"
-         "--expose" "7012-7016"
-         "--expose" "8881"
-         "-p" "8081:8081"
-         "-e" "SPARK_CONF_DIR=/conf"
-         "-v" (str pwd "/conf/worker:/conf")
-         "-v" (str pwd "/data:/tmp/data")
-         "-e" "SPARK_WORKER_CORES=2"
-         "-e" "SPARK_WORKER_MEMORY=1g"
-         "-e" "SPARK_WORKER_PORT=8881"
-         "-e" "SPARK_WORKER_WEBUI_PORT=8081"
-         "gettyimages/spark"
-         "bin/spark-class"
-         "org.apache.spark.deploy.worker.Worker" "spark://master:7077"))
+    (start-master pwd)
+    (Thread/sleep 2000)
+    (start-worker pwd)
+    (Thread/sleep 2000))
   (f)
-  (sh! "docker" "stop" "master")
-  (sh! "docker" "stop" "worker")
-  (sh! "docker" "rm" "master")
-  (sh! "docker" "rm" "worker"))
+  (stop-spark "worker")
+  (stop-spark "master"))
 
 (defn with-connection [f]
   (keg/connect! "spark://localhost:7077")

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -11,9 +11,7 @@
     (.trim out)))
 
 (defn start-master [pwd]
-  (sh! "docker" "run"
-       "-d"
-       "--rm"
+  (sh! "docker" "run" "-d"
        "--name" "master"
        "-h" "master"
        "-p" "8080:8080"
@@ -33,9 +31,7 @@
        "-h" "master"))
 
 (defn start-worker [pwd]
-  (sh! "docker" "run"
-       "-d"
-       "--rm"
+  (sh! "docker" "run" "-d"
        "--name" "worker"
        "--link" "master"
        "-h" "worker"
@@ -54,7 +50,8 @@
        "org.apache.spark.deploy.worker.Worker" "spark://master:7077"))
 
 (defn stop-spark [instance]
-  (sh! "docker" "stop" instance))
+  (sh! "docker" "stop" instance)
+  (sh! "docker" "rm" instance))
 
 (defn with-cluster [f]
   (let [pwd (.getAbsolutePath (java.io.File. ""))]

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -51,7 +51,8 @@
 
 (defn stop-spark [instance]
   (sh! "docker" "stop" instance)
-  (sh! "docker" "rm" instance))
+  (when-not (System/getenv "CIRCLECI")
+    (sh! "docker" "rm" instance)))
 
 (defn with-cluster [f]
   (let [pwd (.getAbsolutePath (java.io.File. ""))]

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -95,8 +95,9 @@
     #(.setContextClassLoader (Thread/currentThread) cl)))
 
 (defn keg-connection [host]
-  (keg/connect! (str "spark://" host ":7077"))
-  #(keg/disconnect!))
+  (fn []
+    (keg/connect! (str "spark://" host ":7077"))
+    #(keg/disconnect!)))
 
 (deftest ^:integration rdd-spark-2.1.0
   (with-resources

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -11,7 +11,9 @@
     (.trim out)))
 
 (defn start-master [pwd]
-  (sh! "docker" "run" "-d"
+  (sh! "docker" "run"
+       "-d"
+       "--rm"
        "--name" "master"
        "-h" "master"
        "-p" "8080:8080"
@@ -31,7 +33,9 @@
        "-h" "master"))
 
 (defn start-worker [pwd]
-  (sh! "docker" "run" "-d"
+  (sh! "docker" "run"
+       "-d"
+       "--rm"
        "--name" "worker"
        "--link" "master"
        "-h" "worker"
@@ -50,8 +54,7 @@
        "org.apache.spark.deploy.worker.Worker" "spark://master:7077"))
 
 (defn stop-spark [instance]
-  (sh! "docker" "stop" instance)
-  (sh! "docker" "rm" instance))
+  (sh! "docker" "stop" instance))
 
 (defn with-cluster [f]
   (let [pwd (.getAbsolutePath (java.io.File. ""))]

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -68,7 +68,13 @@
   (f)
   (keg/disconnect!))
 
-(use-fixtures :once with-cluster with-connection)
+(defn with-cl [f]
+  (let [cl (.getContextClassLoader (Thread/currentThread))]
+    (.setContextClassLoader (Thread/currentThread) (clojure.lang.DynamicClassLoader. cl))
+    (f)
+    (.setContextClassLoader (Thread/currentThread) cl)))
+
+(use-fixtures :once with-cluster with-cl with-connection)
 
 (deftest rdd
   (is (= (into [] (keg/rdd (range 10)))

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -1,0 +1,65 @@
+(ns powderkeg.integration-test
+  (:require [powderkeg.core :as keg]
+            [clojure.test :refer :all]
+            [clojure.java.shell :refer [sh]]
+            [clojure.string :as s]))
+
+(defn sh! [& args]
+  (let [{:keys [exit out] :as ret} (apply sh args)]
+    (when-not (zero? exit)
+      (throw (Exception. (str "Problem while running '" (s/join " " args) "': " out))))
+    out))
+
+(defn with-cluster [f]
+  (let [pwd (.getAbsolutePath (java.io.File. ""))]
+    (sh! "docker" "run" "-d"
+         "--name" "master"
+         "-h" "master"
+         "-p" "8080:8080"
+         "-p" "7077:7077"
+         "-p" "4040:4040"
+         "-p" "6066:6066"
+         "--expose" "7001-7006"
+         "--expose" "7077"
+         "--expose" "6066"
+         "-e" "MASTER=spark://master:7077"
+         "-e" "SPARK_CONF_DIR=/conf"
+         "-v" (str pwd "/conf/master:/conf")
+         "-v" (str pwd "/data:/tmp/data")
+         "gettyimages/spark"
+         "bin/spark-class"
+         "org.apache.spark.deploy.master.Master"
+         "-h" "master")
+    (sh! "docker" "run" "-d"
+         "--name" "worker"
+         "--link" "master"
+         "-h" "worker"
+         "--expose" "7012-7016"
+         "--expose" "8881"
+         "-p" "8081:8081"
+         "-e" "SPARK_CONF_DIR=/conf"
+         "-v" (str pwd "/conf/worker:/conf")
+         "-v" (str pwd "/data:/tmp/data")
+         "-e" "SPARK_WORKER_CORES=2"
+         "-e" "SPARK_WORKER_MEMORY=1g"
+         "-e" "SPARK_WORKER_PORT=8881"
+         "-e" "SPARK_WORKER_WEBUI_PORT=8081"
+         "gettyimages/spark"
+         "bin/spark-class"
+         "org.apache.spark.deploy.worker.Worker" "spark://master:7077"))
+  (f)
+  (sh! "docker" "stop" "master")
+  (sh! "docker" "stop" "worker")
+  (sh! "docker" "rm" "master")
+  (sh! "docker" "rm" "worker"))
+
+(defn with-connection [f]
+  (keg/connect! "spark://localhost:7077")
+  (f)
+  (keg/disconnect!))
+
+(use-fixtures :once with-cluster with-connection)
+
+(deftest rdd
+  (is (= (into [] (keg/rdd (range 10)))
+         (range 10))))

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -57,9 +57,9 @@
 (defn with-cluster [f]
   (let [pwd (.getAbsolutePath (java.io.File. ""))]
     (start-master pwd)
-    (Thread/sleep 2000)
+    (Thread/sleep 4000)
     (start-worker pwd)
-    (Thread/sleep 2000))
+    (Thread/sleep 4000))
   (f)
   (stop-spark "worker")
   (stop-spark "master"))

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -5,9 +5,9 @@
             [clojure.string :as s]))
 
 (defn sh! [& args]
-  (let [{:keys [exit out] :as ret} (apply sh args)]
+  (let [{:keys [exit out err] :as ret} (apply sh args)]
     (when-not (zero? exit)
-      (throw (Exception. (str "Problem while running '" (s/join " " args) "': " out))))
+      (throw (Exception. (str "Problem while running '" (s/join " " args) "': " out " " err))))
     (.trim out)))
 
 (defn start-master [pwd]


### PR DESCRIPTION
Seems that Spark 1.5 works with kryo 3.0.3 while Spark 2 needs kryo 4.0.0. Also use `:target-path "target/%s/"` just to make sure that compiled classes are aware of active profile.

I'm using https://hub.docker.com/r/gettyimages/spark/ for as docker image and while 2.1.0 seems to work neat, when using 1.5.2, one needs to have `master` name mapped to `127.0.0.1` in /etc/hosts.