### PR TITLE
Refactor tests for running same asserts in docker and local mode

### DIFF
--- a/test/powderkeg/asserts.clj
+++ b/test/powderkeg/asserts.clj
@@ -1,5 +1,6 @@
 (ns powderkeg.asserts
   (:require [powderkeg.core :as keg]
+            [net.cgrand.xforms :as x]
             [clojure.test :refer :all]))
 
 (defn example-asserts []
@@ -27,5 +28,12 @@
   (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
          (keg/into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
   (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
-         (into [] (keg/scomp (partition-by #(quot % 6))) (keg/rdd (range 20))))))
+         (into [] (keg/scomp (partition-by #(quot % 6))) (keg/rdd (range 20)))))
+  (is (= {false "2500", true "2550"}
+         (into {}
+               (keg/by-key (range 100)
+                           :key odd?
+                           :pre (map inc)
+                           (x/reduce +)
+                           :post (map str))))))
 

--- a/test/powderkeg/asserts.clj
+++ b/test/powderkeg/asserts.clj
@@ -1,0 +1,31 @@
+(ns powderkeg.asserts
+  (:require [powderkeg.core :as keg]
+            [clojure.test :refer :all]))
+
+(defn example-asserts []
+  (is (= (into [] (keg/rdd (range 10)))
+         (into [] (range 10))))
+  (is (= ["Testing spark"]
+         (into [] (keg/rdd ["This is a firest line"
+                            "Testing spark"
+                            "and powderkeg"
+                            "Happy hacking!"]
+                           (filter #(.contains % "spark"))))))
+  (is (instance? org.apache.spark.api.java.JavaRDD
+                 (keg/rdd (range 100)      ; source
+                          (filter odd?)    ; 1st transducer to apply
+                          (map inc)        ; 2nd transducer
+                          :partitions 2))) ; and options
+  (is (= [0 1 2 3 4 5 6 7 8 9]
+         (into [] (keg/rdd (range 10)))))
+  (is (= [0 1 2 3 4]
+         (into [] (keg/scomp (take 5)) (range 10))))
+  (is (= [0 1 2 3 4]
+         (keg/into [] (take 5) (range 10))))
+  (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17]]
+         (into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
+  (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
+         (keg/into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
+  (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
+         (into [] (keg/scomp (partition-by #(quot % 6))) (keg/rdd (range 20))))))
+

--- a/test/powderkeg/core_test.clj
+++ b/test/powderkeg/core_test.clj
@@ -1,42 +1,39 @@
 (ns powderkeg.core-test
   (:require [powderkeg.core :as keg]
-            [clojure.test :refer :all]))
-
-(defn with-local [f]
-  (keg/connect! "local[2]")
-  (f)
-  (keg/disconnect!))
-
-(use-fixtures :once with-local)
+            [clojure.test :refer :all]
+            [powderkeg.fixtures :refer [with-resources local-spark]]))
 
 (deftest rdd
-  (is (= (into [] (keg/rdd (range 10)))
-         (into [] (range 10))))
-  (is (= ["Testing spark"]
-         (into [] (keg/rdd ["This is a firest line"
-                            "Testing spark"
-                            "and powderkeg"
-                            "Happy hacking!"]
-                           (filter #(.contains % "spark"))))))
-  (is (instance? org.apache.spark.api.java.JavaRDD
-                 (keg/rdd (range 100)      ; source
-                          (filter odd?)    ; 1st transducer to apply
-                          (map inc)        ; 2nd transducer
-                          :partitions 2))) ; and options
-  (is (= [0 1 2 3 4 5 6 7 8 9]
-         (into [] (keg/rdd (range 10)))))
-  (is (= [0 1 2 3 4]
-         (into [] (keg/scomp (take 5)) (range 10))))
-  (is (= [0 1 2 3 4]
-         (keg/into [] (take 5) (range 10))))
-  (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17]]
-         (into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
-  (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
-         (keg/into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
-  (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
-         (into [] (keg/scomp (partition-by #(quot % 6))) (keg/rdd (range 20))))))
-
+  (with-resources
+    [local-spark]
+    (is (= (into [] (keg/rdd (range 10)))
+           (into [] (range 10))))
+    (is (= ["Testing spark"]
+           (into [] (keg/rdd ["This is a firest line"
+                              "Testing spark"
+                              "and powderkeg"
+                              "Happy hacking!"]
+                             (filter #(.contains % "spark"))))))
+    (is (instance? org.apache.spark.api.java.JavaRDD
+                   (keg/rdd (range 100)      ; source
+                            (filter odd?)    ; 1st transducer to apply
+                            (map inc)        ; 2nd transducer
+                            :partitions 2))) ; and options
+    (is (= [0 1 2 3 4 5 6 7 8 9]
+           (into [] (keg/rdd (range 10)))))
+    (is (= [0 1 2 3 4]
+           (into [] (keg/scomp (take 5)) (range 10))))
+    (is (= [0 1 2 3 4]
+           (keg/into [] (take 5) (range 10))))
+    (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17]]
+           (into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
+    (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
+           (keg/into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
+    (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
+           (into [] (keg/scomp (partition-by #(quot % 6))) (keg/rdd (range 20)))))))
 
 (deftest pair-rdd
-  (is (instance? org.apache.spark.api.java.JavaRDD
-                 (keg/rdd {:a 1 :b 2}))))
+  (with-resources
+    [local-spark]
+    (is (instance? org.apache.spark.api.java.JavaRDD
+                   (keg/rdd {:a 1 :b 2})))))

--- a/test/powderkeg/core_test.clj
+++ b/test/powderkeg/core_test.clj
@@ -1,36 +1,13 @@
 (ns powderkeg.core-test
   (:require [powderkeg.core :as keg]
             [clojure.test :refer :all]
-            [powderkeg.fixtures :refer [with-resources local-spark]]))
+            [powderkeg.fixtures :refer [with-resources local-spark]]
+            [powderkeg.asserts :refer [example-asserts]]))
 
 (deftest rdd
   (with-resources
     [local-spark]
-    (is (= (into [] (keg/rdd (range 10)))
-           (into [] (range 10))))
-    (is (= ["Testing spark"]
-           (into [] (keg/rdd ["This is a firest line"
-                              "Testing spark"
-                              "and powderkeg"
-                              "Happy hacking!"]
-                             (filter #(.contains % "spark"))))))
-    (is (instance? org.apache.spark.api.java.JavaRDD
-                   (keg/rdd (range 100)      ; source
-                            (filter odd?)    ; 1st transducer to apply
-                            (map inc)        ; 2nd transducer
-                            :partitions 2))) ; and options
-    (is (= [0 1 2 3 4 5 6 7 8 9]
-           (into [] (keg/rdd (range 10)))))
-    (is (= [0 1 2 3 4]
-           (into [] (keg/scomp (take 5)) (range 10))))
-    (is (= [0 1 2 3 4]
-           (keg/into [] (take 5) (range 10))))
-    (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17]]
-           (into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
-    (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
-           (keg/into [] (partition-by #(quot % 6)) (keg/rdd (range 20)))))
-    (is (= [[0 1 2 3 4 5] [6 7 8 9 10 11] [12 13 14 15 16 17] [18 19]]
-           (into [] (keg/scomp (partition-by #(quot % 6))) (keg/rdd (range 20)))))))
+    (example-asserts)))
 
 (deftest pair-rdd
   (with-resources

--- a/test/powderkeg/fixtures.clj
+++ b/test/powderkeg/fixtures.clj
@@ -1,0 +1,20 @@
+(ns powderkeg.fixtures
+  (:require [powderkeg.core :as keg]))
+
+(defmacro with-resources
+  "Setup resources and tear them down after running body.
+  Takes a function, which when called, will setup necessary resources,
+  and returns a function, which when called, will tear the resources down.
+
+  Can be given multiple setup functions, which are called in order"
+  [setups & body]
+  (if-some [[setup & setups] (seq setups)]
+    `(let [teardown# (~setup)]
+       (try
+         (with-resources [~@setups] ~@body)
+         (finally (teardown#))))
+    `(do ~@body)))
+
+(defn local-spark []
+  (keg/connect! "local[2]")
+  #(keg/disconnect!))

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -1,5 +1,6 @@
 (ns powderkeg.integration-test
   (:require [powderkeg.core :as keg]
+            [powderkeg.fixtures :refer [with-resources]]
             [clojure.test :refer :all]
             [clojure.java.shell :refer [sh]]
             [clojure.string :as s]))
@@ -58,20 +59,6 @@
   (sh! "docker" "stop" instance)
   (when-not (System/getenv "CIRCLECI")
     (sh! "docker" "rm" instance)))
-
-(defmacro with-resources
-  "Setup resources and tear them down after running body.
-  Takes a function, which when called, will setup necessary resources,
-  and returns a function, which when called, will tear the resources down.
-
-  Can be given multiple setup functions, which are called in order"
-  [setups & body]
-  (if-some [[setup & setups] (seq setups)]
-    `(let [teardown# (~setup)]
-       (try
-         (with-resources [~@setups] ~@body)
-         (finally (teardown#))))
-    `(do ~@body)))
 
 (defn start-spark [version]
   (let [pwd (.getAbsolutePath (java.io.File. ""))]

--- a/test/powderkeg/integration_test.clj
+++ b/test/powderkeg/integration_test.clj
@@ -1,6 +1,7 @@
 (ns powderkeg.integration-test
   (:require [powderkeg.core :as keg]
             [powderkeg.fixtures :refer [with-resources]]
+            [powderkeg.asserts :refer [example-asserts]]
             [clojure.test :refer :all]
             [clojure.java.shell :refer [sh]]
             [clojure.string :as s]))
@@ -91,13 +92,11 @@
     [(spark "2.1.0-hadoop-2.7")
      clojure-dynamic-classloader
      (keg-connection "localhost")]
-    (is (= (into [] (keg/rdd (range 10)))
-           (range 10)))))
+    (example-asserts)))
 
 (deftest ^:integration rdd-spark-1.5.2
   (with-resources
     [(spark "1.5.2-hadoop-2.6")
      clojure-dynamic-classloader
      (keg-connection "master")]
-    (is (= (into [] (keg/rdd (range 10)))
-           (range 10)))))
+    (example-asserts)))


### PR DESCRIPTION
Idea is to be able to run same tests against local mode and a Spark in a separate process (2.1 and 1.5). Could probably be factored so that a `deftest` form would not have to decide where to run tests, but this could be a starting point.