### PR TITLE
Instruct to add kryo 4.0.0 as dependency on Spark 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ E.g.
 
 ```clj
 :dependencies [[hcadatalab/powderkeg "0.5.1"]
+               [com.esotericsoftware/kryo-shaded "4.0.0"]  ;; For Spark 2.x support
                [org.apache.spark/spark-core_2.11 "2.1.0"]
                [org.apache.spark/spark-streaming_2.11 "2.1.0"]]
 ```


### PR DESCRIPTION
Otherwise serialization exceptions like this will follow:

```
Serialization trace:
org$apache$spark$storage$BlockManagerId$$executorId_ (org.apache.spark.storage.BlockManagerId)
	at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:1276)
	at org.apache.spark.broadcast.TorrentBroadcast.readBroadcastBlock(TorrentBroadcast.scala:206)
	at org.apache.spark.broadcast.TorrentBroadcast._value$lzycompute(TorrentBroadcast.scala:66)
	at org.apache.spark.broadcast.TorrentBroadcast._value(TorrentBroadcast.scala:66)
	at org.apache.spark.broadcast.TorrentBroadcast.getValue(TorrentBroadcast.scala:96)
	at org.apache.spark.broadcast.Broadcast.value(Broadcast.scala:70)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:81)
	at org.apache.spark.scheduler.Task.run(Task.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:282)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: com.esotericsoftware.kryo.KryoException: java.lang.IndexOutOfBoundsException: Index: 4002, Size: 1
Serialization trace:
org$apache$spark$storage$BlockManagerId$$executorId_ (org.apache.spark.storage.BlockManagerId)
	at com.esotericsoftware.kryo.serializers.ObjectField.read(ObjectField.java:144)
	at com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:551)
	at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:790)
	at org.apache.spark.serializer.KryoDeserializationStream.readObject(KryoSerializer.scala:244)
	at org.apache.spark.broadcast.TorrentBroadcast$$anonfun$10.apply(TorrentBroadcast.scala:286)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1303)
	at org.apache.spark.broadcast.TorrentBroadcast$.unBlockifyObject(TorrentBroadcast.scala:287)
	at org.apache.spark.broadcast.TorrentBroadcast$$anonfun$readBroadcastBlock$1.apply(TorrentBroadcast.scala:221)
	at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:1269)
	... 11 more
Caused by: java.lang.IndexOutOfBoundsException: Index: 4002, Size: 1
	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
	at java.util.ArrayList.get(ArrayList.java:429)
	at com.esotericsoftware.kryo.util.MapReferenceResolver.getReadObject(MapReferenceResolver.java:60)
	at com.esotericsoftware.kryo.Kryo.readReferenceOrNull(Kryo.java:834)
	at com.esotericsoftware.kryo.Kryo.readObjectOrNull(Kryo.java:757)
	at com.esotericsoftware.kryo.serializers.ObjectField.read(ObjectField.java:132)
	... 19 more
```